### PR TITLE
Fix color error on redit menu

### DIFF
--- a/redit.c
+++ b/redit.c
@@ -419,7 +419,7 @@ static void redit_disp_menu(struct descriptor_data *d)
   sprintbitarray(room->room_flags, room_bits, RF_ARRAY_MAX, buf1);
   sprinttype(room->sector_type, sector_types, buf2, sizeof(buf2));
   write_to_output(d,
-	  "-- Room number : [%s%d%s]  	Room zone: [%s%d%s]\r\n"
+	  "-- Room number : [%s%d%s]       Room zone: [%s%d%s]\r\n"
 	  "%s1%s) Name        : %s%s\r\n"
 	  "%s2%s) Description :\r\n%s%s"
 	  "%s3%s) Room flags  : %s%s\r\n"


### PR DESCRIPTION
A tab snuck into the redit menu, making errant color show up. Removed the tab.
