### PR TITLE
Additional modifications to flight

### DIFF
--- a/act.h
+++ b/act.h
@@ -170,6 +170,8 @@ ACMD(do_sleep);
 ACMD(do_stand);
 ACMD(do_fly);
 ACMD(do_wake);
+/* Utility functions */
+int has_flight(struct char_data *ch);
 /* Global variables from act.movement.c */
 #ifndef __ACT_MOVEMENT_C__
 extern const char *cmd_door[];

--- a/act.informative.c
+++ b/act.informative.c
@@ -182,7 +182,7 @@ static void list_affections_to_char(struct char_data *ch)
     send_to_char(ch, "Your eyes are glowing red.\r\n");
 	count++;
   }
-  if (AFF_FLAGGED(ch, AFF_FLYING)) {
+  if (AFF_FLAGGED(ch, AFF_FLIGHT)) {
     send_to_char(ch, "You have the ability to fly.\r\n");
 	count++;
   }
@@ -1227,7 +1227,7 @@ ACMD(do_score)
       send_to_char(ch, "You are standing.\r\n");
       break;
     case POS_FLYING:
-      send_to_char(ch, "You are flying.\r\n");
+      send_to_char(ch, "You are hovering.\r\n");
       break;
     default:
       send_to_char(ch, "You are floating.\r\n");

--- a/act.item.c
+++ b/act.item.c
@@ -49,8 +49,6 @@ static void perform_wear(struct char_data *ch, struct obj_data *obj, int where);
 static void wear_message(struct char_data *ch, struct obj_data *obj, int where);
 
 
-
-
 static void perform_put(struct char_data *ch, struct obj_data *obj, struct obj_data *cont)
 {
 
@@ -76,8 +74,16 @@ static void perform_put(struct char_data *ch, struct obj_data *obj, struct obj_d
       SET_BIT_AR(GET_OBJ_EXTRA(cont), ITEM_NODROP);
       act("You get a strange feeling as you put $p in $P.", FALSE,
                 ch, obj, cont, TO_CHAR);
-    } else
+    } else {
       act("You put $p in $P.", FALSE, ch, obj, cont, TO_CHAR);
+  
+      /* did they put away the thing that was allowing them to fly? */
+      if ((GET_POS(ch) == POS_FLYING) && !has_flight(ch)) {
+        send_to_char(ch, "You land on the ground.\r\n");
+        act("$n stops hovering, and settles to the ground.", TRUE, ch, 0, 0, TO_ROOM);
+        GET_POS(ch) = POS_STANDING;
+      }
+    }
   }
 }
 
@@ -461,6 +467,13 @@ static int perform_drop(struct char_data *ch, struct obj_data *obj,
   act(buf, TRUE, ch, obj, 0, TO_ROOM);
 
   obj_from_char(obj);
+  
+  /* did they drop the thing that was allowing them to fly? */
+  if ((GET_POS(ch) == POS_FLYING) && !has_flight(ch)) {
+    send_to_char(ch, "You land on the ground.\r\n");
+    act("$n stops hovering, and settles to the ground.", TRUE, ch, 0, 0, TO_ROOM);
+    GET_POS(ch) = POS_STANDING;
+  }
 
   if ((mode == SCMD_DONATE) && OBJ_FLAGGED(obj, ITEM_NODONATE))
     mode = SCMD_JUNK;
@@ -625,6 +638,13 @@ static void perform_give(struct char_data *ch, struct char_data *vict,
   act("You give $p to $N.", FALSE, ch, obj, vict, TO_CHAR);
   act("$n gives you $p.", FALSE, ch, obj, vict, TO_VICT);
   act("$n gives $p to $N.", TRUE, ch, obj, vict, TO_NOTVICT);
+  
+  /* did they give away the thing that was allowing them to fly? */
+  if ((GET_POS(ch) == POS_FLYING) && !has_flight(ch)) {
+    send_to_char(ch, "You land on the ground.\r\n");
+    act("$n stops hovering, and settles to the ground.", TRUE, ch, 0, 0, TO_ROOM);
+    GET_POS(ch) = POS_STANDING;
+  }  
   
   autoquest_trigger_check( ch, vict, obj, AQ_OBJ_RETURN);
 }
@@ -1527,6 +1547,13 @@ static void perform_remove(struct char_data *ch, int pos)
     obj_to_char(unequip_char(ch, pos), ch);
     act("You stop using $p.", FALSE, ch, obj, 0, TO_CHAR);
     act("$n stops using $p.", TRUE, ch, obj, 0, TO_ROOM);
+    
+    /* did they give remove the thing that was allowing them to fly? */
+    if ((GET_POS(ch) == POS_FLYING) && !has_flight(ch)) {
+      send_to_char(ch, "You land on the ground.\r\n");
+      act("$n stops hovering, and settles to the ground.", TRUE, ch, 0, 0, TO_ROOM);
+      GET_POS(ch) = POS_STANDING;
+    }
   }
 }
 

--- a/act.movement.c
+++ b/act.movement.c
@@ -69,17 +69,17 @@ int has_flight(struct char_data *ch)
   if (GET_LEVEL(ch) > LVL_IMMORT)
     return (1);
 
-  if (AFF_FLAGGED(ch, AFF_FLYING))
+  if (AFF_FLAGGED(ch, AFF_FLIGHT))
     return (1);
 
   /* Non-wearable flying items in inventory will do it. */
   for (obj = ch->carrying; obj; obj = obj->next_content)
-    if (OBJAFF_FLAGGED(obj, AFF_FLYING) && OBJAFF_FLAGGED(obj, AFF_FLYING))
+    if (OBJAFF_FLAGGED(obj, AFF_FLIGHT) && (find_eq_pos(ch, obj, NULL) < 0) && !CAN_WEAR(obj, ITEM_WEAR_WIELD))
       return (1);
 
-  /* Any equipped objects with AFF_FLYING will do it too. */
+  /* Any equipped objects with AFF_FLIGHT will do it too. */
   for (i = 0; i < NUM_WEARS; i++)
-    if (GET_EQ(ch, i) && OBJAFF_FLAGGED(GET_EQ(ch, i), AFF_FLYING))
+    if (GET_EQ(ch, i) && OBJAFF_FLAGGED(GET_EQ(ch, i), AFF_FLIGHT))
       return (1);
 
   return (0);

--- a/act.other.c
+++ b/act.other.c
@@ -238,6 +238,12 @@ ACMD(do_steal)
 	    obj_from_char(obj);
 	    obj_to_char(obj, ch);
 	    send_to_char(ch, "Got it!\r\n");
+        /* if the item that was allowing them to fly was stolen, put them on the ground */
+        if (OBJAFF_FLAGGED(obj, AFF_FLIGHT) && (GET_POS(vict) == POS_FLYING) && !has_flight(vict)) {
+          send_to_char(vict, "You land on the ground.\r\n");
+          act("$n stops hovering, and settles to the ground.", TRUE, vict, 0, 0, TO_ROOM);
+          GET_POS(vict) = POS_STANDING;
+        }
 	  }
 	} else
 	  send_to_char(ch, "You cannot carry that much.\r\n");

--- a/constants.c
+++ b/constants.c
@@ -293,7 +293,7 @@ const char *affected_bits[] =
   "PROT-GOOD",
   "SLEEP",
   "NO_TRACK",
-  "FLY",
+  "FLIGHT",
   "SCUBA",
   "SNEAK",
   "HIDE",

--- a/spell_parser.c
+++ b/spell_parser.c
@@ -844,7 +844,7 @@ void mag_assign_spells(void)
     
   spello(SPELL_FLY, "fly", 40, 20, 2, POS_FIGHTING,
 	TAR_CHAR_ROOM, FALSE, MAG_AFFECTS,
-	"You drift slowly to the ground.");
+	"Your ability to fly fades.");
 
   spello(SPELL_GROUP_HEAL, "group heal", 80, 60, 5, POS_STANDING,
 	TAR_IGNORE, FALSE, MAG_GROUPS,

--- a/structs.h
+++ b/structs.h
@@ -323,7 +323,7 @@
 #define AFF_PROTECT_GOOD   14   /**< Char protected from good */
 #define AFF_SLEEP          15   /**< (R) Char magically asleep */
 #define AFF_NOTRACK        16   /**< Char can't be tracked */
-#define AFF_FLYING         17   /**< Char is flying */
+#define AFF_FLIGHT         17   /**< Char can fly */
 #define AFF_SCUBA          18   /**< Room for future expansion */
 #define AFF_SNEAK          19   /**< Char can move quietly */
 #define AFF_HIDE           20   /**< Char is hidden */


### PR DESCRIPTION
Changed flag name from FLYING to FLIGHT. Made it so has_flight() is the universal way to know if a character can fly. (Currently in act.movement.c and act.h, may move it to a more utilitarian place.) When removing/giving/putting/junking/stealing an object that gives FLIGHT, the character is returned to the ground. When the fly spell wears off, also return the person to the ground.
