### PR TITLE
Add arena flags

### DIFF
--- a/act.informative.c
+++ b/act.informative.c
@@ -1119,8 +1119,12 @@ ACMD(do_score)
     CCYEL(ch, C_NRM), CBCYN(ch, C_NRM), GET_MOVE(ch), CCNRM(ch, C_NRM), CCCYN(ch, C_NRM), 
     GET_MAX_MOVE(ch), CCYEL(ch, C_NRM), CBGRN(ch, C_NRM), add_commas(GET_EXP(ch)), CCNRM(ch, C_NRM));
   
-  send_to_char(ch, "\r\n    \twKills \ty:  \tn%6s		\trDeaths \ty:  \tn%d\r\n", 
-    add_commas(GET_KILL_CNT(ch)), GET_RIP_CNT(ch));
+  send_to_char(ch, "\r\n %sKills %s:    Mob         PK      Arena"
+                  "     %sDeaths %s:    Mob         PK      Arena\r\n"
+                  "%s      %9s  %9s  %9s           %9s  %9s  %9s\r\n",
+                  CCWHT(ch, C_NRM), CCYEL(ch, C_NRM), CCRED(ch, C_NRM), CCYEL(ch, C_NRM), CCNRM(ch, C_NRM),
+                  add_commas(0), add_commas(GET_KILL_CNT(ch)), add_commas(GET_ARENA_KILL_CNT(ch)), 
+                  add_commas(0), add_commas(GET_RIP_CNT(ch)), add_commas(GET_ARENA_RIP_CNT(ch)));
   
   send_to_char(ch, "%s-------------------------------------------------------------------------------%s\r\n", 
     CCRED(ch, C_NRM), CCNRM(ch, C_NRM));

--- a/constants.c
+++ b/constants.c
@@ -92,6 +92,7 @@ const char *room_bits[] = {
   "*",				/* The BFS Mark. */
   "WORLDMAP",
   "!TEL",
+  "ARENA",
   "\n"
 };
 
@@ -106,6 +107,7 @@ const char *zone_bits[] = {
   "NOBUILD",
   "!ASTRAL",
   "WORLDMAP",
+  "ARENA",
   "\n"
 };
 
@@ -189,11 +191,7 @@ const char *player_bits[] = {
   "IBT_BUG",
   "IBT_IDEA",
   "IBT_TYPO",
-  "UNUSED1",
-  "UNUSED2",
-  "UNUSED3",
-  "UNUSED4",
-  "UNUSED5",
+  "ARENA",
   "\n"
 };
 

--- a/fight.h
+++ b/fight.h
@@ -21,6 +21,7 @@ struct attack_hit_type {
 };
 
 /* Functions available in fight.c */
+bool is_arena_combat(struct char_data *ch, struct char_data *vict);
 void appear(struct char_data *ch);
 void check_killer(struct char_data *ch, struct char_data *vict);
 int compute_armor_class(struct char_data *ch);

--- a/pfdefaults.h
+++ b/pfdefaults.h
@@ -36,6 +36,8 @@
 #define PFDEF_SOUL_POINTS   0
 #define PFDEF_RIP_CNT		0
 #define PFDEF_KILL_CNT		0
+#define PFDEF_ARENA_RIP_CNT		0
+#define PFDEF_ARENA_KILL_CNT    0
 #define PFDEF_DT_CNT		0
 #define PFDEF_CLAN			0
 #define PFDEF_CLAN_RANK		0

--- a/players.c
+++ b/players.c
@@ -285,6 +285,8 @@ int load_char(const char *name, struct char_data *ch)
 	GET_SOUL_POINTS(ch) = PFDEF_SOUL_POINTS;
 	GET_RIP_CNT(ch) = PFDEF_RIP_CNT;
 	GET_KILL_CNT(ch) = PFDEF_KILL_CNT;
+    GET_ARENA_RIP_CNT(ch) = PFDEF_ARENA_RIP_CNT;
+	GET_ARENA_KILL_CNT(ch) = PFDEF_ARENA_KILL_CNT;
 	GET_DT_CNT(ch) = PFDEF_DT_CNT;
 	GET_CLAN(ch) = PFDEF_CLAN;
 	GET_CLAN_RANK(ch) = PFDEF_CLAN_RANK;
@@ -353,6 +355,8 @@ int load_char(const char *name, struct char_data *ch)
 	if (!strcmp(tag, "Affs")) 	load_affects(fl, ch);
         else if (!strcmp(tag, "Alin"))	GET_ALIGNMENT(ch)	= atoi(line);
 	else if (!strcmp(tag, "Alis"))	read_aliases_ascii(fl, ch, atoi(line));
+    else if (!strcmp(tag, "ARip"))	GET_ARENA_RIP_CNT(ch)	= atoi(line);
+    else if (!strcmp(tag, "AKil"))	GET_ARENA_KILL_CNT(ch)	= atoi(line);
 	break;
 
       case 'B':
@@ -669,6 +673,8 @@ void save_char(struct char_data * ch)
   
   if (GET_RIP_CNT(ch)  != PFDEF_RIP_CNT)	fprintf(fl, "Rip : %d\n", GET_RIP_CNT(ch));
   if (GET_KILL_CNT(ch)  != PFDEF_KILL_CNT)	fprintf(fl, "Kill: %d\n", GET_KILL_CNT(ch));
+  if (GET_ARENA_RIP_CNT(ch)  != PFDEF_ARENA_RIP_CNT)	fprintf(fl, "ARip: %d\n", GET_ARENA_RIP_CNT(ch));
+  if (GET_ARENA_KILL_CNT(ch)  != PFDEF_ARENA_KILL_CNT)	fprintf(fl, "AKil: %d\n", GET_ARENA_KILL_CNT(ch));
   if (GET_DT_CNT(ch)  != PFDEF_DT_CNT)	fprintf(fl, "DTs : %d\n", GET_DT_CNT(ch));
 
   if (GET_COND(ch, HUNGER)   != PFDEF_HUNGER && GET_LEVEL(ch) < LVL_IMMORT) fprintf(fl, "Hung: %d\n", GET_COND(ch, HUNGER));

--- a/structs.h
+++ b/structs.h
@@ -96,9 +96,10 @@
 #define ROOM_OLC           14   /**< (R) Modifyable/!compress */
 #define ROOM_BFS_MARK      15   /**< (R) breath-first srch mrk */
 #define ROOM_WORLDMAP      16   /**< World-map style maps here */
-#define ROOM_NOTELEPORT	   17   // Room cannot be teleported into
+#define ROOM_NOTELEPORT	   17   /**< Room cannot be teleported into */
+#define ROOM_ARENA         18   /**< Deaths in this room are arena */
 /** The total number of Room Flags */
-#define NUM_ROOM_FLAGS    18
+#define NUM_ROOM_FLAGS     19
 
 /* Zone info: Used in zone_data.zone_flags */
 #define ZONE_CLOSED       0  /**< Zone is closed - players cannot enter */
@@ -107,9 +108,10 @@
 #define ZONE_GRID         3  /**< Zone is 'on the grid', connected, show on 'areas' */
 #define ZONE_NOBUILD      4  /**< Building is not allowed in the zone */
 #define ZONE_NOASTRAL     5  /**< No teleportation magic will work to or from this zone */
-#define ZONE_WORLDMAP     6 /**< Whole zone uses the WORLDMAP by default */
+#define ZONE_WORLDMAP     6  /**< Whole zone uses the WORLDMAP by default */
+#define ZONE_ARENA        7  /**< Deaths in zone are arena */
 /** The total number of Zone Flags */
-#define NUM_ZONE_FLAGS    7
+#define NUM_ZONE_FLAGS    8
 
 /* Exit info: used in room_data.dir_option.exit_info */
 #define EX_ISDOOR     (1 << 0)   /**< Exit is a door		*/
@@ -235,6 +237,7 @@
 #define PLR_BUG          17   /**< Player is writing a bug */
 #define PLR_IDEA         18   /**< Player is writing an idea */
 #define PLR_TYPO         19   /**< Player is writing a typo */
+#define PLR_ARENA        20   /**< Player is arena-saved */
 
 /* Mobile flags: used by char_data.char_specials.act */
 #define MOB_SPEC            0   /**< Mob has a callable spec-proc */
@@ -1123,6 +1126,8 @@ struct player_special_data_saved
   int soul_points;		  /* Number of soul points */
   int rip_cnt;		  	  /* Number of deaths */
   int kill_cnt;		  	  /* Number of kills */
+  int arena_rip_cnt;      /* Number of arena deaths */
+  int arena_kill_cnt;     /* Number of arena kills */
   int dt_cnt;		  	  /* Number of DTs hit */
   qst_vnum *completed_quests;   /**< Quests completed              */
   int    num_completed_quests;  /**< Number completed              */

--- a/utils.h
+++ b/utils.h
@@ -583,6 +583,10 @@ do                                                              \
 #define GET_RIP_CNT(ch)     CHECK_PLAYER_SPECIAL((ch), ((ch)->player_specials->saved.rip_cnt))
 /* Number of kills for ch */
 #define GET_KILL_CNT(ch)    CHECK_PLAYER_SPECIAL((ch), ((ch)->player_specials->saved.kill_cnt))
+/* Number of arena deaths for ch */
+#define GET_ARENA_RIP_CNT(ch)     CHECK_PLAYER_SPECIAL((ch), ((ch)->player_specials->saved.arena_rip_cnt))
+/* Number of arena kills for ch */
+#define GET_ARENA_KILL_CNT(ch)    CHECK_PLAYER_SPECIAL((ch), ((ch)->player_specials->saved.arena_kill_cnt))
 /* Number of times hit DT for ch */
 #define GET_DT_CNT(ch)      CHECK_PLAYER_SPECIAL((ch), ((ch)->player_specials->saved.dt_cnt))
 /** Current invisibility level of ch. */
@@ -894,7 +898,7 @@ do                                                              \
 /* Returns TRUE if the direction is a diagonal one */
 #define IS_DIAGONAL(dir) (((dir) == NORTHWEST) || ((dir) == NORTHEAST) || \
 		((dir) == SOUTHEAST) || ((dir) == SOUTHWEST) )
-
+        
 /** Return the class abbreviation for ch. */
 #define CLASS_ABBR(ch) (IS_NPC(ch) ? "--" : class_abbrevs[(int)GET_CLASS(ch)])
 


### PR DESCRIPTION
Add arena flags so that when a character dies in an arena flagged room or zone they don't lose equipment or experience etc. Add arena room and zone flag. Add arena_rip_cnt and arena_kill_cnt. Added full counts to do_score(). Added is_arena_combat() to check if the kill was in arena.
