### PR TITLE
Separate pc and npc class defines

### DIFF
--- a/class.c
+++ b/class.c
@@ -39,13 +39,22 @@ const char *class_abbrevs[] = {
   "Drui",
   "Thie",
   "Psio",
-  "None",
+  "Unsd",   /*  10 */
+  "Unsd", "Unsd", "Unsd", "Unsd", "Unsd", 
+  "Unsd", "Unsd", "Unsd", "Unsd", "Unsd",   /*  20 */
+  "Unsd", "Unsd", "Unsd", "Unsd", "Unsd", 
+  "Unsd", "Unsd", "Unsd", "Unsd", "Unsd",   /*  30 */
+  "Unsd", "Unsd", "Unsd", "Unsd", "Unsd", 
+  "Unsd", "Unsd", "Unsd", "Unsd", "Unsd",   /*  40 */
+  "Unsd", "Unsd", "Unsd", "Unsd", "Unsd", 
+  "Unsd", "Unsd", "Unsd", "Unsd",
+  "None",   /* 50 Start Mob Classes */
   "Mobl",
   "\n"
 };
 
 const char *class_types[] = {
-  "Knight",
+  "Knight",     /*   0 */
   "Cleric",
   "Barbarian",
   "Ranger",
@@ -55,7 +64,16 @@ const char *class_types[] = {
   "Druid",
   "Thief",
   "Psionicist",
-  "None",
+  "Unused",     /*  10 */
+  "Unused", "Unused", "Unused", "Unused", "Unused",
+  "Unused", "Unused", "Unused", "Unused", "Unused", /*  20 */
+  "Unused", "Unused", "Unused", "Unused", "Unused",
+  "Unused", "Unused", "Unused", "Unused", "Unused", /*  30 */
+  "Unused", "Unused", "Unused", "Unused", "Unused",
+  "Unused", "Unused", "Unused", "Unused", "Unused", /*  40 */
+  "Unused", "Unused", "Unused", "Unused", "Unused",
+  "Unused", "Unused", "Unused", "Unused",
+  "None",       /*  50 Start Mob Classes */
   "Mobile",
   "\n"
 };
@@ -71,7 +89,16 @@ const char *classplural_types[] = {
   "Druids",
   "Thieves",
   "Psionicists",
-  "Classless",
+  "Unused",     /*  10 */
+  "Unused", "Unused", "Unused", "Unused", "Unused",
+  "Unused", "Unused", "Unused", "Unused", "Unused", /*  20 */
+  "Unused", "Unused", "Unused", "Unused", "Unused",
+  "Unused", "Unused", "Unused", "Unused", "Unused", /*  30 */
+  "Unused", "Unused", "Unused", "Unused", "Unused",
+  "Unused", "Unused", "Unused", "Unused", "Unused", /*  40 */
+  "Unused", "Unused", "Unused", "Unused", "Unused",
+  "Unused", "Unused", "Unused", "Unused",
+  "Classless",  /*  50 Start Mob Classes */
   "Mobiles",
   "\n"
 };

--- a/medit.c
+++ b/medit.c
@@ -348,12 +348,20 @@ void medit_disp_class(struct descriptor_data *d)
   get_char_colors(d->character);
   clear_screen(d);
 
-  write_to_output(d, "\r\n Available npc classes: \r\n\r\n");
+  write_to_output(d, "\r\n Classes available to PCs: \r\n\r\n");
   
-  for (i = 0; i < NUM_CLASSES; i++) {
+  for (i = 0; i < NUM_PC_CLASSES; i++) {
     sprintf(flags, "  %s%2d%s) %s\r\n", grn, i, nrm, class_types[i]);
     write_to_output(d, "%s", flags);
   }
+  
+  write_to_output(d, "\r\n Classes available to NPCs: \r\n\r\n");
+  
+  for (i = FIRST_MOB_CLASS; i < NUM_CLASSES; i++) {
+    sprintf(flags, "  %s%2d%s) %s\r\n", grn, i, nrm, class_types[i]);
+    write_to_output(d, "%s", flags);
+  }
+  
   write_to_output(d, "\r\n Enter class number : ");
 }
 
@@ -366,12 +374,20 @@ void medit_disp_remort(struct descriptor_data *d)
   get_char_colors(d->character);
   clear_screen(d);
 
-  write_to_output(d, "\r\n Available npc classes: \r\n\r\n");
+  write_to_output(d, "\r\n Classes available to PCs: \r\n\r\n");
   
-  for (i = 0; i < NUM_CLASSES; i++) {
+  for (i = 0; i < NUM_PC_CLASSES; i++) {
     sprintf(flags, "  %s%2d%s) %s\r\n", grn, i, nrm, class_types[i]);
     write_to_output(d, "%s", flags);
   }
+  
+  write_to_output(d, "\r\n Classes available to NPCs: \r\n\r\n");
+  
+  for (i = FIRST_MOB_CLASS; i < NUM_CLASSES; i++) {
+    sprintf(flags, "  %s%2d%s) %s\r\n", grn, i, nrm, class_types[i]);
+    write_to_output(d, "%s", flags);
+  }
+  
   write_to_output(d, "\r\n Enter class number : ");
 }
 
@@ -1016,11 +1032,17 @@ void medit_parse(struct descriptor_data *d, char *arg)
     break;
 	
   case MEDIT_CLASS:
-    GET_CLASS(OLC_MOB(d)) = LIMIT(i, 0, NUM_CLASSES -1);
+    if ((i >= 0 && i < NUM_PC_CLASSES) || (i >= FIRST_MOB_CLASS && i < NUM_CLASSES))
+      GET_CLASS(OLC_MOB(d)) = i;
+    else
+      GET_CLASS(OLC_MOB(d)) = FIRST_MOB_CLASS;
     break;
 	
   case MEDIT_REMORT:
-    GET_REMORT(OLC_MOB(d)) = LIMIT(i, 0, NUM_CLASSES -1);
+    if ((i >= 0 && i < NUM_PC_CLASSES) || (i >= FIRST_MOB_CLASS && i < NUM_CLASSES))
+      GET_REMORT(OLC_MOB(d)) = i;
+    else
+      GET_REMORT(OLC_MOB(d)) = FIRST_MOB_CLASS;
     break;
 
   case MEDIT_SEX:

--- a/structs.h
+++ b/structs.h
@@ -157,6 +157,7 @@
 #define GROUP_NPC     (1 << 2)  /**< Group created by NPC and thus not listed */
 
 /* Classes */
+/* PC Classes */
 #define CLASS_UNDEFINED	  -1
 #define CLASS_KNIGHT       0
 #define CLASS_CLERIC       1
@@ -168,11 +169,14 @@
 #define CLASS_DRUID        7
 #define CLASS_THIEF        8
 #define CLASS_PSIONICIST   9
-#define CLASS_NONE		  10
-#define CLASS_MOBILE	  11 
-
-/** Total number of available Classes */
-#define NUM_CLASSES	  	  12
+/* Total number of PC Classes */
+#define NUM_PC_CLASSES    10
+/* Mobile Classes */
+#define FIRST_MOB_CLASS   50
+#define CLASS_NONE		  50
+#define CLASS_MOBILE	  51 
+/* Total number of available Classes */
+#define NUM_CLASSES	  	  52
 
 /* Races */
 #define RACE_UNDEFINED   	-1


### PR DESCRIPTION
This separates the defines for PC classes and NPC classes. It's mostly to manage new additions to PC classes so that they aren't added to weird areas later on. This allows expansion up to 50 PC classes.
