### PR TITLE
Fix object recalculate to prototype on oedit save

### DIFF
--- a/genobj.c
+++ b/genobj.c
@@ -33,7 +33,9 @@ obj_rnum add_object(struct obj_data *newobj, obj_vnum ovnum)
   /* Write object to internal tables. */
   if ((newobj->item_number = real_object(ovnum)) != NOTHING) {
     copy_object(&obj_proto[newobj->item_number], newobj);
-    update_all_objects(&obj_proto[newobj->item_number]);
+    /* the next line has been removed to stop objects from being recalculated to match prototypes
+       when an object edit is saved to disk */
+    // update_all_objects(&obj_proto[newobj->item_number]);
     add_to_save_list(zone_table[rznum].number, SL_OBJ);
     return newobj->item_number;
   }


### PR DESCRIPTION
Resolves issue #45. Looking for input on whether this is the best way to keep objects from resetting to the prototype values on oedit save.
