### PR TITLE
Add authors list to zone information

### DIFF
--- a/act.wizard.c
+++ b/act.wizard.c
@@ -2462,7 +2462,7 @@ static size_t print_zone_to_buf(char *bufptr, size_t left, zone_rnum zone, int l
 
     tmp = snprintf(bufptr, left,
 	"%3d %-30.30s%s By: %-10.10s%s Age: %3d; Reset: %3d (%s); Range: %5d-%5d\r\n",
-	zone_table[zone].number, zone_table[zone].name, KNRM, zone_table[zone].builders, KNRM,
+	zone_table[zone].number, zone_table[zone].name, KNRM, zone_table[zone].authors, KNRM,
 	zone_table[zone].age, zone_table[zone].lifespan,
         zone_table[zone].reset_mode ? ((zone_table[zone].reset_mode == 1) ? "Reset when no players are in zone" : "Normal reset") : "Never reset",
 	zone_table[zone].bot, zone_table[zone].top);
@@ -2511,7 +2511,7 @@ static size_t print_zone_to_buf(char *bufptr, size_t left, zone_rnum zone, int l
     return snprintf(bufptr, left,
         "%3d %-*s%s By: %-10.10s%s Range: %5d-%5d\r\n", zone_table[zone].number,
 	count_color_chars(zone_table[zone].name)+30, zone_table[zone].name, KNRM,
-	zone_table[zone].builders, KNRM, zone_table[zone].bot, zone_table[zone].top);
+	zone_table[zone].authors, KNRM, zone_table[zone].bot, zone_table[zone].top);
 }
 
 ACMD(do_show)
@@ -2597,7 +2597,7 @@ ACMD(do_show)
         builder = 1;
       for (len = zrn = 0; zrn <= top_of_zone_table; zrn++) {
         if (*value) {
-          buf2 = strtok(strdup(zone_table[zrn].builders), " ");
+          buf2 = strtok(strdup(zone_table[zrn].authors), " ");
           while (buf2) {
             if (!str_cmp(buf2, value)) {
               if (builder == 1)
@@ -4915,7 +4915,7 @@ ACMD(do_zlock)
 
         send_to_char(ch, "[%s%3d%s] %s%-*s %s%-1s%s\r\n",
           QGRN, zone_table[zn].number, QNRM, QCYN, count_color_chars(zone_table[zn].name)+30, zone_table[zn].name,
-          QYEL, zone_table[zn].builders ? zone_table[zn].builders : "None.", QNRM);
+          QYEL, zone_table[zn].authors ? zone_table[zn].authors : "None.", QNRM);
         counter++;
       }
     }
@@ -5009,7 +5009,7 @@ ACMD(do_zunlock)
 
         send_to_char(ch, "[%s%3d%s] %s%-*s %s%-1s%s\r\n",
           QGRN, zone_table[zn].number, QNRM, QCYN, count_color_chars(zone_table[zn].name)+30, zone_table[zn].name,
-          QYEL, zone_table[zn].builders ? zone_table[zn].builders : "None.", QNRM);
+          QYEL, zone_table[zn].authors ? zone_table[zn].authors : "None.", QNRM);
         counter++;
       }
     }

--- a/db.c
+++ b/db.c
@@ -609,6 +609,8 @@ void destroy_db(void)
   for (cnt = 0; cnt <= top_of_zone_table; cnt++) {
     if (zone_table[cnt].name)
       free(zone_table[cnt].name);
+    if (zone_table[cnt].authors)
+      free(zone_table[cnt].authors);
     if (zone_table[cnt].builders)
       free(zone_table[cnt].builders);
     if (zone_table[cnt].cmd) {
@@ -2140,6 +2142,11 @@ static void load_zones(FILE *fl, char *zonename)
   }
   snprintf(buf2, sizeof(buf2), "beginning of zone #%d", Z.number);
 
+  line_num += get_line(fl, buf);
+  if ((ptr = strchr(buf, '~')) != NULL) /* take off the '~' if it's there */
+    *ptr = '\0';
+  Z.authors = strdup(buf);
+  
   line_num += get_line(fl, buf);
   if ((ptr = strchr(buf, '~')) != NULL) /* take off the '~' if it's there */
     *ptr = '\0';

--- a/db.h
+++ b/db.h
@@ -175,9 +175,9 @@ struct reset_com {
 
 /* zone definition structure. for the 'zone-table'   */
 struct zone_data {
-   char	*name;		    /* name of this zone                  */
-   char *builders;          /* namelist of builders allowed to    */
-                            /* modify this zone.		  */
+   char	*name;		        /* name of this zone                  */
+   char *authors;           /* name list of the creators of the zone   */
+   char *builders;          /* name list of builders allowed to modify this zone. */
    int	lifespan;           /* how long between resets (minutes)  */
    int	age;                /* current age of this zone (minutes) */
    room_vnum bot;           /* starting room number for this zone */

--- a/genolc.c
+++ b/genolc.c
@@ -393,7 +393,7 @@ static int export_info_file(zone_rnum zrnum)
   }
 
   fprintf(info_file, "The files accompanying this info file contain the area: %s\n", zone_table[zrnum].name);
-  fprintf(info_file, "It was written by: %s.\n\n", zone_table[zrnum].builders);
+  fprintf(info_file, "It was written by: %s.\n\n", zone_table[zrnum].authors);
   fprintf(info_file, "The author has given permission to distribute the area, provided credit is\n");
   fprintf(info_file, "given. The area may be modified as you see fit, except you are not allowed to\n");
   fprintf(info_file, "remove the builder name or credits.\n\n");
@@ -627,8 +627,8 @@ static int export_save_zone(zone_rnum zrnum)
                  "%s~\n"
                  "%s~\n"
                  "QQ%02d QQ%02d %d %d\n",
-	  (zone_table[zrnum].builders && *zone_table[zrnum].builders)
-		? zone_table[zrnum].builders : "None.",
+	  (zone_table[zrnum].authors && *zone_table[zrnum].authors)
+		? zone_table[zrnum].authors : "None.",
 	  (zone_table[zrnum].name && *zone_table[zrnum].name)
 		? zone_table[zrnum].name : "undefined",
           genolc_zone_bottom(zrnum)%100,

--- a/genzon.c
+++ b/genzon.c
@@ -194,6 +194,7 @@ rznum = i;
   /* Ok, insert the new zone here. */
   zone->name = strdup("New Zone");
   zone->number = vzone_num;
+  zone->authors = strdup("None");
   zone->builders = strdup("None");
   zone->bot = bottom;
   zone->top = top;
@@ -359,8 +360,11 @@ int save_zone(zone_rnum zone_num)
     fprintf(zfile, "#%d\n"
                    "%s~\n"
                    "%s~\n"
+                   "%s~\n"
                    "%d %d %d %d\n",
            zone_table[zone_num].number,
+          (zone_table[zone_num].authors && *zone_table[zone_num].authors)
+                ? zone_table[zone_num].authors : "None.",
           (zone_table[zone_num].builders && *zone_table[zone_num].builders)
                 ? zone_table[zone_num].builders : "None.",
           (zone_table[zone_num].name && *zone_table[zone_num].name)
@@ -380,8 +384,11 @@ int save_zone(zone_rnum zone_num)
     fprintf(zfile, "#%d\n"
                    "%s~\n"
                    "%s~\n"
+                   "%s~\n"
                    "%d %d %d %d %s %s %s %s %d %d\n",       /* New tbaMUD data line */
            zone_table[zone_num].number,
+          (zone_table[zone_num].authors && *zone_table[zone_num].authors)
+                ? zone_table[zone_num].authors : "None.",
           (zone_table[zone_num].builders && *zone_table[zone_num].builders)
                 ? zone_table[zone_num].builders : "None.",
           (zone_table[zone_num].name && *zone_table[zone_num].name)

--- a/oasis.c
+++ b/oasis.c
@@ -116,6 +116,8 @@ void cleanup_olc(struct descriptor_data *d, byte cleanup_type)
 
   /* Check for a zone.  cleanup_type is irrelevant here, free() everything. */
   if (OLC_ZONE(d)) {
+    if (OLC_ZONE(d)->authors)
+      free(OLC_ZONE(d)->authors);
     if (OLC_ZONE(d)->builders)
       free(OLC_ZONE(d)->builders);
     if (OLC_ZONE(d)->name)
@@ -291,7 +293,7 @@ int can_edit_zone(struct char_data *ch, zone_rnum rnum)
   if (GET_LEVEL(ch) >= LVL_GRGOD && PRF_FLAGGED(ch, PRF_WORLD_WRITE))
     return (TRUE);
 
-  /* always access if a player helped build the zone in the first place */
+  /* always access if on the builders list */
   if (rnum != HEDIT_PERMISSION && rnum != AEDIT_PERMISSION)
     if (is_name(GET_NAME(ch), zone_table[rnum].builders))
       return (TRUE);

--- a/oasis.h
+++ b/oasis.h
@@ -246,7 +246,8 @@ extern const char *nrm, *grn, *cyn, *yel;
 #define ZEDIT_ZONE_TOP			  14
 #define ZEDIT_ZONE_RESET		  15
 #define ZEDIT_CONFIRM_SAVESTRING  16
-#define ZEDIT_ZONE_BUILDERS		  17
+#define ZEDIT_ZONE_AUTHORS		  17
+#define ZEDIT_ZONE_BUILDERS		  18
 #define ZEDIT_SARG1               20
 #define ZEDIT_SARG2               21
 #define ZEDIT_ZONE_FLAGS          22

--- a/oasis_list.c
+++ b/oasis_list.c
@@ -779,7 +779,7 @@ static void list_zones(struct char_data *ch, zone_rnum rnum, zone_vnum vmin, zon
   }
 
   len = snprintf(buf, sizeof(buf),
-  "VNum  Zone Name                      Builder(s)\r\n"
+  "VNum  Zone Name                      Author(s)\r\n"
   "----- ------------------------------ --------------------------------------\r\n");
 
   if (!top_of_zone_table)
@@ -787,12 +787,12 @@ static void list_zones(struct char_data *ch, zone_rnum rnum, zone_vnum vmin, zon
 
   for (i = 0; i <= top_of_zone_table; i++) {
     if (zone_table[i].number >= bottom && zone_table[i].number <= top) {
-      if ((!use_name) || (is_name(name, zone_table[i].builders))) {
+      if ((!use_name) || (is_name(name, zone_table[i].authors))) {
           counter++;
           
         tmp_len = snprintf(buf+len, sizeof(buf)-len, "[%s%3d%s] %s%-*s %s%-1s%s\r\n",
         QGRN, zone_table[i].number, QNRM, QCYN, count_color_chars(zone_table[i].name)+30, zone_table[i].name,
-        QYEL, zone_table[i].builders ? zone_table[i].builders : "None.", QNRM);
+        QYEL, zone_table[i].authors ? zone_table[i].authors : "None.", QNRM);
         len += tmp_len;
         if (len > sizeof(buf))
           break;
@@ -865,6 +865,7 @@ void print_zone(struct char_data *ch, zone_vnum vnum)
   send_to_char(ch,
     "%sVirtual Number = %s%d\r\n"
     "%sName of zone   = %s%s\r\n"
+    "%sAuthors        = %s%s\r\n"
     "%sBuilders       = %s%s\r\n"
     "%sLifespan       = %s%d\r\n"
     "%sAge            = %s%d\r\n"
@@ -883,6 +884,7 @@ void print_zone(struct char_data *ch, zone_vnum vnum)
     "%s   Quests      = %s%d%s\r\n",
     QGRN, QCYN, zone_table[rnum].number,
     QGRN, QCYN, zone_table[rnum].name,
+    QGRN, QCYN, zone_table[rnum].authors,
     QGRN, QCYN, zone_table[rnum].builders,
     QGRN, QCYN, zone_table[rnum].lifespan,
     QGRN, QCYN, zone_table[rnum].age,


### PR DESCRIPTION
This adds an authors list to a zone, similar to builders list. This allows for the name of the author of the zone to be saved, but makes it so they don't have permanent edit on the zone. Partially resolves #40.
